### PR TITLE
Avoid infinite loop due to not finding the default voice

### DIFF
--- a/Source/NJRVoicePopUpButton.m
+++ b/Source/NJRVoicePopUpButton.m
@@ -220,12 +220,21 @@ typedef NS_ENUM(NSInteger, NJRVoiceVisibility) {
 
 - (void)setVoice:(NSString *)voice;
 {
-    NSInteger voiceIdx = [self indexOfItemWithRepresentedObject: voice];
+    NSInteger voiceIdx = [self getIndexForVoice: voice];
     if (voiceIdx == -1) {
         [self _invalidateVoiceSelection];
         return;
     }
     [self selectItemAtIndex: voiceIdx];
+}
+
+- (NSInteger) getIndexForVoice:(NSString *)voiceId {
+    NSInteger voiceIdx = [self indexOfItemWithRepresentedObject: voiceId];
+    if (voiceIdx > -1) {
+	return voiceIdx;
+    }
+    // try again with '.premium' suffix
+    return [self indexOfItemWithRepresentedObject: [voiceId stringByAppendingString:@".premium"]];
 }
 
 - (void)_previewVoice;


### PR DESCRIPTION
It seems that [NSSpeechSynthesizer defaultVoice] returns a voice ID
which is not necessarily available in the list of voices returned by
[NSSpeechSynthesizer availableVoices]. (It appears that installing
the high quality voices results in voice IDs with ».premium« suffix in
the list given by +availableVoices while +defaultVoice returns the
original ID.)

This makes NJRVoicePopUpButton go into an infinite loop 
_refreshVoiceList → setVoice: → _invalidateSeletedVoice
→ _refreshVoiceList…

Short of understanding how to resolve this properly by avoiding an
infinite loop for good, this patch tries to find a voice with
the given ID and the suffix ».premium«.

Infinite loop and default voice name in the debugger:
![pester infinite loop](https://cloud.githubusercontent.com/assets/40549/11546342/f29425ea-994c-11e5-9cfc-d8edfdbda3f0.png)
